### PR TITLE
Bump actions/checkout to v4

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,7 +6,7 @@ jobs:
   units:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v4
     - run: npm ci
     - run: npm test
 
@@ -14,7 +14,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v4
     - uses: ./
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
node.js libraries with version lower than 20 are deprecated. 
To fix this deprecation you need to update the actions/checkout library to version 4.
